### PR TITLE
Added several functions

### DIFF
--- a/.scripts/system-stats.c
+++ b/.scripts/system-stats.c
@@ -25,8 +25,7 @@ static void kernel(char *);
 static void ram(char *);
 static void cpu(char *);
 static void volume(char *);
-static const char *shorten_stream(const char *);
-static void song(char *, int8_t);
+static void song(char *);
 static void drive(char *);
 static void loads(char *);
 static void up(char *);
@@ -57,7 +56,7 @@ int main(void) {
   kernel(k);
   ram(r);
   volume(v);
-  song(s, 0); // change the number to obtain different information
+  song(s);
   drive(d);
   loads(l);
   up(u);
@@ -258,32 +257,19 @@ error:
   EXIT();
 }
 
-static const char *
-shorten_stream(const char *str1) {
-  const char *stream = str1;
-
-  if (5 < (strlen(stream))) {
-    if (0 == (strncmp(stream, "http", 4))) {
-      stream = "..";
-    }
-  }
-  return stream;
-}
-
 static void
-song(char *str1, int8_t num) {
+song(char *str1) {
 
   struct mpd_connection *conn = NULL;
   struct mpd_song *song = NULL;
-  const char *stream = NULL, *taggy = NULL;
-  static const int8_t tagz_arr[] = {
-    0,
-    MPD_TAG_TRACK,
-    MPD_TAG_ARTIST,
-    MPD_TAG_TITLE,
-    MPD_TAG_ALBUM,
-    MPD_TAG_DATE
-  };
+  const char *s1 = NULL, *s2 = NULL;
+
+  // Available tags
+  // MPD_TAG_TRACK
+  // MPD_TAG_ARTIST
+  // MPD_TAG_TITLE
+  // MPD_TAG_ALBUM
+  // MPD_TAG_DATE
 
   *str1 = '\0';
   if (NULL == (conn = mpd_connection_new(NULL, 0, 0))) {
@@ -297,14 +283,11 @@ song(char *str1, int8_t num) {
     goto error;
   }
 
-  if (6 != num) {
-    taggy = mpd_song_get_tag(song, tagz_arr[num], 0);
-    if (NULL != taggy) {
-      FILL_ARR(str1, taggy);
-    }
-  } else {
-    if (NULL != (stream = mpd_song_get_uri(song))) {
-      FILL_ARR(str1, (shorten_stream(stream)));
+  s1 = mpd_song_get_tag(song, MPD_TAG_TITLE, 0);
+  if (NULL != s1) {
+    s2 = mpd_song_get_tag(song, MPD_TAG_ARTIST, 0);
+    if (NULL != s2) {
+      snprintf(str1, VLA, "%s %s", s1, s2);
     }
   }
 

--- a/.scripts/system-stats.c
+++ b/.scripts/system-stats.c
@@ -99,10 +99,10 @@ static void
 packs(char *str1) {
   uint_fast16_t packages = 0;
 
-  //packages = glob_packages("/var/lib/pacman/local/*");
+  packages = glob_packages("/var/lib/pacman/local/*");
 
   //  Gentoo
-  packages = glob_packages("/var/db/pkg/*/*");
+  //packages = glob_packages("/var/db/pkg/*/*");
 
   snprintf(str1, VLA, "%"PRIuFAST16, packages);
 }

--- a/.scripts/system-stats.c
+++ b/.scripts/system-stats.c
@@ -312,5 +312,5 @@ drive(char *str1) {
   }
 
   val = (uintmax_t)((drive.f_blocks - drive.f_bfree) * drive.f_bsize) / GB;
-  snprintf(str1, VLA, "%"PRIuMAX, val);
+  snprintf(str1, VLA, FMT_UINT, val);
 }

--- a/.scripts/system-stats.c
+++ b/.scripts/system-stats.c
@@ -74,7 +74,7 @@ taim(char *str1) {
 
   if (-1 == (t = time(NULL)) || 
       NULL == (taim = localtime(&t)) ||
-      0 == (strftime(time_str, VLA, "%b %d, %Y / %H:%M", taim))) {
+      0 == (strftime(time_str, VLA, "%b %d, %Y\n%H:%M", taim))) {
     EXIT();
   }
   FILL_ARR(str1, time_str);


### PR DESCRIPTION
Hello Quinn,

Added the alsa function to obtain the current volume in percentage.

Added five more functions that show mpd (I presume that you have *libmpdclient* installed) information and the second one will obtain the drive usage in percentage, the third one is the average load that is shown in the `uptime` command, the fourth one is uptime converted into proper formatting so it matches either days, hours and/or minutes since the computer have been booted, the fifth one is the motherboard voltage one.

Right now the program obtains the load regarding all cpu cores, do you want to obtain the load per cpu core/thread instead ?

Here's what the load per core looks like ![2017-10-06-174845_113x22_scrot](https://user-images.githubusercontent.com/29376083/31286749-7348307a-aabf-11e7-8bd8-5dc4b9dc1e76.png)


```bash
50 Cent - Get In My Car
load 0.04 0.31 0.21
up 1h 13m
Oct 07, 2017
11:54
packs 771
Linux 4.12.12-gentoo
ram 8%
cpu 0%
drive 48%
voltage 1.36 3.34 5.04 12.28
vol 68%
```


su8